### PR TITLE
Update ehemalige.md

### DIFF
--- a/docs/ehemalige.md
+++ b/docs/ehemalige.md
@@ -1,14 +1,14 @@
 Ehemalige des Gewerbehofs
 =========================
 
-* [Anti Atom AG Karlsruhe](http://antiatomkarlsruhe.blogsport.de/)
+* Anti Atom AG Karlsruhe
 * [Bicibene (Christoph Quante)](http://www.bicibene.com/)
 * [DFG-VK](http://www.dfg-vk.de/willkommen/)
 * [Druckcooperative](http://www.druckcoop.de/)
 * [Henrys](http://www.henrys-online.de/)
 * [Initial](http://initial-karlsruhe.de/)
-* [Pfau e.V.](http://pfau-ev.i-networx.de/)
-* [Pichler Rad](http://www.pichlerrad.de/)
+* Pfau e.V.
+* Pichler Rad
 * [SaaS Web Internet Solutions](https://www.saasweb.net/de)
 * Soli - Gegen den neoliberalen Zeitgeist. Seien wir realistisch, versuchen wir das Unmögliche.
 * [Tanzfoyee](http://www.tanzfoyer.de/)


### PR DESCRIPTION
Kaputte links auf der Seite Ehemalige entfernt. Die Liste der Ehemaligen ist auch bei weitem nicht vollständig und sollte noch ergänzt werden.